### PR TITLE
fix she-bang

### DIFF
--- a/tools/rst2md.py
+++ b/tools/rst2md.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 rst2md.py


### PR DESCRIPTION
Hardcoding the python interpreter in the she-bang is a really bad idea. It does not allow you to use the python interpreter that comes first on the `$PATH`.
